### PR TITLE
Reduce Docker image size and support login args abbreviations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM alpine:3.11
+FROM python:3.8-alpine3.11
 
 COPY requirements.txt .
 COPY remove-dockerhub-tag.py .
 
-RUN apk add --no-cache python3 py3-pip && \
-    pip3 install -r requirements.txt && \
-    apk del --purge py3-pip && \
-    rm -rf /var/cache/apk/* /tmp/*
+RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["python3", "remove-dockerhub-tag.py"]

--- a/remove-dockerhub-tag.py
+++ b/remove-dockerhub-tag.py
@@ -4,8 +4,8 @@ import argparse
 import re
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--user', required=True, help='dockerhub username')
-parser.add_argument('--password', required=True, help='dockerhub password')
+parser.add_argument('-u', '--user', required=True, help='dockerhub username')
+parser.add_argument('-p', '--password', required=True, help='dockerhub password')
 parser.add_argument('image', nargs='+', help='org/image:tag')
 args = parser.parse_args()
 


### PR DESCRIPTION
Docker image size shrinks from `64.1MB` to `51.2MB`